### PR TITLE
Add minimal boardgame.io config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Aussie-Estates
+# Aussie Estates
+
+This repository contains a minimal boardgame.io configuration for an Australian-themed property trading game. It demonstrates a simple setup with two phases:
+
+- **Buy** – players can roll dice and purchase the property they land on.
+- **EndGame** – triggered after 20 turns, awarding victory to the richest player.
+
+See `server/game/index.ts` for the implementation.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aussie-estates",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "boardgame.io": "^1.4.0"
+  }
+}

--- a/server/game/index.ts
+++ b/server/game/index.ts
@@ -1,0 +1,96 @@
+import { Game, TurnOrder, INVALID_MOVE } from 'boardgame.io';
+
+export interface Property {
+  price: number;
+  owner: string | null;
+}
+
+export interface PlayerState {
+  position: number;
+  cash: number;
+  properties: number[];
+}
+
+export interface GameState {
+  players: Record<string, PlayerState>;
+  properties: Property[];
+  turn: number;
+  gameOver: boolean;
+}
+
+const boardSize = 10;
+const propertyPrice = 100;
+
+export const AussieGame: Game<GameState> = {
+  setup: ({ ctx }) => {
+    const properties: Property[] = Array.from({ length: boardSize }, () => ({
+      price: propertyPrice,
+      owner: null,
+    }));
+    const players: Record<string, PlayerState> = {};
+    for (let i = 0; i < ctx.numPlayers; i++) {
+      players[i.toString()] = { position: 0, cash: 1500, properties: [] };
+    }
+    return { players, properties, turn: 0, gameOver: false };
+  },
+
+  turn: {
+    order: TurnOrder.DEFAULT,
+  },
+
+  phases: {
+    Buy: {
+      start: true,
+      moves: { rollDice, buyProperty },
+      endIf: (G) => (G.gameOver ? true : undefined),
+      onEnd: (G) => {
+        G.turn++;
+        if (G.turn >= 20) {
+          G.gameOver = true;
+        }
+      },
+    },
+    EndGame: {
+      moves: {},
+      start: false,
+      onBegin: () => {},
+    },
+  },
+
+  endIf: (G) => (G.gameOver ? { winner: highestCash(G) } : undefined),
+};
+
+function rollDice(G: GameState, ctx: any) {
+  const player = G.players[ctx.currentPlayer];
+  const dice = ctx.random.D6();
+  player.position = (player.position + dice) % boardSize;
+}
+
+function buyProperty(G: GameState, ctx: any) {
+  const player = G.players[ctx.currentPlayer];
+  const property = G.properties[player.position];
+  if (property.owner !== null) {
+    return INVALID_MOVE;
+  }
+  if (player.cash < property.price) {
+    return INVALID_MOVE;
+  }
+  property.owner = ctx.currentPlayer;
+  player.cash -= property.price;
+  player.properties.push(player.position);
+}
+
+function highestCash(G: GameState) {
+  let winner = null;
+  let maxCash = -Infinity;
+  for (const id in G.players) {
+    const cash = G.players[id].cash;
+    if (cash > maxCash) {
+      maxCash = cash;
+      winner = id;
+    }
+  }
+  return winner;
+}
+
+export default AussieGame;


### PR DESCRIPTION
## Summary
- add basic boardgame.io configuration with Buy and EndGame phases
- include simple README
- scaffold package.json with boardgame.io dependency

## Testing
- `npm install boardgame.io @types/node --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686661c67e488323b2d7fd83b5a6cbc7