### PR TITLE
Fix Express server duplication

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,23 +5,15 @@ import lobbyRouter from './lobby';
 
 const app = express();
 app.use(express.json());
-app.use(lobbyRouter);
+app.use('/api', lobbyRouter);
 
-const server = Server({
+const boardGameServer = Server({
   games: [AussieGame],
 });
 
-const PORT = process.env.PORT || 4000;
-app.listen(PORT, () => {
-  console.log(`Server listening on ${PORT}`);
+const port = Number(process.env.PORT) || 4000;
+app.listen(port, () => {
+  console.log(`Server listening on ${port}`);
 });
 
-server.run(PORT + 1);
-import lobbyRouter from './src/lobby';
-
-const app = express();
-app.use(express.json());
-app.use('/api/lobby', lobbyRouter);
-
-const port = process.env.PORT || 3001;
-app.listen(port, () => console.log(`Server running on ${port}`));
+boardGameServer.run(port + 1);


### PR DESCRIPTION
## Summary
- refactor server/index.ts to use a single Express app
- mount lobby router once at `/api`
- start the boardgame.io server on a separate port

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686667400e348323abec045c9d3aec82