### PR TITLE
Add TypeScript server build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "dev:client": "next dev",
     "dev:server": "ts-node server/index.ts",
     "dev": "concurrently \"pnpm run dev:client\" \"pnpm run dev:server\"",
-    "build": "next build",
-    "start": "NODE_ENV=production node server/index.js",
+    "build:server": "tsc --project tsconfig.json",
+    "build": "next build && pnpm run build:server",
+    "start": "NODE_ENV=production node dist/index.js",
     "seed": "ts-node scripts/seedBoard.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a build:server script to compile TypeScript
- run build:server from the main build script
- run the compiled server in `pnpm start`

## Testing
- `pnpm run build:server` *(fails: Cannot find module 'fs'...)*
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686671f6ea3c83239011e76d58587a5b