### PR TITLE
Switch resume route to POST

### DIFF
--- a/client/pages/play/[room].tsx
+++ b/client/pages/play/[room].tsx
@@ -14,7 +14,13 @@ export default function PlayRoom() {
 
   useEffect(() => {
     if (!room) return;
-    fetch(`/api/resume?room=${room}`)
+    fetch('/api/resume', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ roomId: room }),
+    })
       .then((res) => res.json())
       .then((data) => setSaved(data));
   }, [room]);

--- a/server/lobby.ts
+++ b/server/lobby.ts
@@ -39,8 +39,8 @@ router.post('/room', async (req, res) => {
   res.json({ roomId, playerId });
 });
 
-router.get('/resume', async (req, res) => {
-  const roomId = req.query.room as string;
+router.post('/resume', async (req, res) => {
+  const { roomId } = req.body as { roomId: string };
   const state = await loadGame(roomId);
   res.json(state);
 });


### PR DESCRIPTION
## Summary
- change `/resume` from GET to POST on the server
- send `roomId` in the body from the client when resuming a game

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*
- `npx tsc -p tsconfig.client.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68667822636c8323ac54bed726d0fb51