### PR TITLE
Resume initial boardgame state

### DIFF
--- a/client/pages/play/[room].tsx
+++ b/client/pages/play/[room].tsx
@@ -10,7 +10,7 @@ import { AussieGame } from '../../../server/game';
 export default function PlayRoom() {
   const router = useRouter();
   const { room } = router.query;
-  const [saved, setSaved] = useState<any>(null);
+  const [initialState, setInitialState] = useState<any>(null);
 
   useEffect(() => {
     if (!room) return;
@@ -22,7 +22,7 @@ export default function PlayRoom() {
       body: JSON.stringify({ roomId: room }),
     })
       .then((res) => res.json())
-      .then((data) => setSaved(data));
+      .then((data) => setInitialState(data));
   }, [room]);
 
   const GameClient = useMemo(() => {
@@ -33,8 +33,9 @@ export default function PlayRoom() {
       multiplayer: SocketIO({
         server: process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:4001',
       }),
+      initialState,
     });
-  }, [room]);
+  }, [room, initialState]);
 
   if (!GameClient || !room) return <p>Loading...</p>;
 


### PR DESCRIPTION
## Summary
- fetch `/api/resume` and supply the result to the boardgame.io `Client` through `initialState`
- drop unused `saved` variable

## Testing
- `npx tsc --project tsconfig.client.json --noEmit` *(fails: Cannot find module 'react')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68667b34f25c8323965b6dbb5880fbfc