### PR TITLE
Add detailed property fields

### DIFF
--- a/server/game/setup.ts
+++ b/server/game/setup.ts
@@ -1,7 +1,8 @@
-import board from '../data/board.json';
-import { GameState } from './types';
+import boardData from '../data/board.json';
+import { GameState, Property } from './types';
 
 export function setup(): GameState {
+  const board: Property[] = boardData as Property[];
   return {
     board,
     players: [],

--- a/server/game/types.ts
+++ b/server/game/types.ts
@@ -6,7 +6,10 @@ export interface PlayerState {
 export interface Property {
   id: string;
   name: string;
-  price: number;
+  price?: number;
+  type: string;
+  colour?: string;
+  rent?: number[];
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- expand `Property` interface to include `type`, `colour` and `rent`
- cast JSON board data to the new `Property` type in `setup`

## Testing
- `npm run build:server` *(fails: Cannot find module 'fs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68667ce9ad6083238929ccb4230d02dc